### PR TITLE
Cross-platform path fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,19 @@ module.exports = function(options) {
 					.then(function(normalized) {
 						return System.locate({name: normalized, metadata: {}});
 					})
-					.then(function(address) {
+					.then(function (address) {
+						var fromRelativeSource = isPath ? process.cwd() : file.base; // take first path from gulp location or current file
+					    
+						var originalRelativePath = path.relative(fromRelativeSource, path.resolve(address.replace('file:', '').replace('.js', '')));
+						var originalRelativePathArray = originalRelativePath.split(path.sep);
+						var posixRelativePath = path.posix.join.apply(this, originalRelativePathArray);
+
 						if (isPath) {
 							options.includePaths.push(
-									address.replace('file:', '').replace('.js', '')
+									posixRelativePath
 							);
 						} else {
-							replacements[i] = path.relative(file.base, address.replace('file:', '').replace('.js', ''));
+							replacements[i] = posixRelativePath;
 						}
 					});
 		}

--- a/index.js
+++ b/index.js
@@ -50,17 +50,14 @@ module.exports = function(options) {
 						return System.locate({name: normalized, metadata: {}});
 					})
 					.then(function (address) {
-						var fromRelativeSource = isPath ? process.cwd() : file.base; // take first path from gulp location or current file
-					    
-						var originalRelativePath = path.relative(fromRelativeSource, path.resolve(address.replace('file:', '').replace('.js', '')));
-						var originalRelativePathArray = originalRelativePath.split(path.sep);
-						var posixRelativePath = path.posix.join.apply(this, originalRelativePathArray);
-
-						if (isPath) {
+					    if (isPath) {
 							options.includePaths.push(
-									posixRelativePath
+									path.resolve(address.replace('file:', '').replace('.js', ''))
 							);
 						} else {
+							var originalRelativePath = path.relative(path.dirname(file.path), path.resolve(address.replace('file:', '').replace('.js', '')));
+							var originalRelativePathArray = originalRelativePath.split(path.sep);
+							var posixRelativePath = path.posix.join.apply(this, originalRelativePathArray);
 							replacements[i] = posixRelativePath;
 						}
 					});

--- a/test.js
+++ b/test.js
@@ -26,14 +26,14 @@ it('should resolve the import string', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : __dirname,
-		path    : __dirname + '/file.ext',
+		base    : '',
+		path    : '/file.ext',
 		contents: new Buffer(fixture)
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), expected);
-		assert.deepEqual(includePaths, [__dirname + "/path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, ["path/resolved/bourbon"]);
 		done();
 	});
 
@@ -44,8 +44,8 @@ it('shoud not throw exception when no resolution needed', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : __dirname,
-		path    : __dirname + '/file.ext',
+		base    : '',
+		path    : '/file.ext',
 		contents: new Buffer("@import './variable/test.scss'")
 	}));
 
@@ -63,14 +63,14 @@ it('should append path', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : __dirname,
-		path    : __dirname + '/file.ext',
+		base    : '',
+		path    : '/file.ext',
 		contents: new Buffer(fixture)
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), expected);
-		assert.deepEqual(includePaths, ["Exemple1", __dirname + "/path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, ["Exemple1", "path/resolved/bourbon"]);
 		done();
 	});
 
@@ -83,14 +83,14 @@ it('should resolve path', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : __dirname,
-		path    : __dirname + '/file.ext',
+		base    : '',
+		path    : '/file.ext',
 		contents: new Buffer('/* @importPath "~bourbon" */')
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), '/* @importPath "~bourbon" */');
-		assert.deepEqual(includePaths, [ __dirname + "/path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, [ "path/resolved/bourbon"]);
 		done();
 	});
 

--- a/test.js
+++ b/test.js
@@ -26,14 +26,14 @@ it('should resolve the import string', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : '',
-		path    : '/file.ext',
+		base    : __dirname,
+		path    : __dirname + '/file.ext',
 		contents: new Buffer(fixture)
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), expected);
-		assert.deepEqual(includePaths, ["path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, [__dirname + "/path/resolved/bourbon"]);
 		done();
 	});
 
@@ -44,8 +44,8 @@ it('shoud not throw exception when no resolution needed', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : '',
-		path    : '/file.ext',
+		base    : __dirname,
+		path    : __dirname + '/file.ext',
 		contents: new Buffer("@import './variable/test.scss'")
 	}));
 
@@ -63,14 +63,14 @@ it('should append path', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : '',
-		path    : '/file.ext',
+		base    : __dirname,
+		path    : __dirname + '/file.ext',
 		contents: new Buffer(fixture)
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), expected);
-		assert.deepEqual(includePaths, ["Exemple1", "path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, ["Exemple1", __dirname + "/path/resolved/bourbon"]);
 		done();
 	});
 
@@ -83,14 +83,14 @@ it('should resolve path', function(done) {
 	var stream = systemResolver({systemConfig: './fixtures/config.js', includePaths: includePaths});
 
 	stream.write(new gutil.File({
-		base    : '',
-		path    : '/file.ext',
+		base    : __dirname,
+		path    : __dirname + '/file.ext',
 		contents: new Buffer('/* @importPath "~bourbon" */')
 	}));
 
 	stream.on('data', function(file) {
 		assert.strictEqual(file.contents.toString('utf8'), '/* @importPath "~bourbon" */');
-		assert.deepEqual(includePaths, [ "path/resolved/bourbon"]);
+		assert.deepEqual(includePaths, [ __dirname + "/path/resolved/bourbon"]);
 		done();
 	});
 


### PR DESCRIPTION
Fixes relative path issue with Windows system.
It should always take unix style path so sass files can be referenced correctly.
There are two different behaviours:
- import: get relative path based on current file path
- importPath: get relative path based on gulp file path, so correct includePaths values can be given to gulp-sass

I've also stumbled upon issue when imported file requires additional imports via systemjs resolution. For more info see dlmanning/gulp-sass/issues/290.
