### PR TITLE
Fix for invalid path on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,12 +52,12 @@ module.exports = function(options) {
 					.then(function(address) {
 						if (isPath) {
 							options.includePaths.push(
-									path.resolve(address.replace('file:', '').replace('.js', ''))
+									path.resolve(address.replace('file:///', '').replace('.js', ''))
 							);
 						} else {
 							var originalRelativePath      = path.relative(
 									path.dirname(file.path),
-									path.resolve(address.replace('file:', '').replace('.js', ''))
+									path.resolve(address.replace('file:///', '').replace('.js', ''))
 							);
 							var originalRelativePathArray = originalRelativePath.split(path.sep);
 


### PR DESCRIPTION
To address a bug in windows that returns invalid path

ERROR:   src\app\foo\styles\main.scss
Error: File to import not found or unreadable: ../../../../../../../C:/data/solutions/MyApp/src/jspm_packages/github/at-import/breakpoint@2.6.1/stylesheets/breakpoint
       Parent style sheet: stdin
        on line 3 of stdin
