### PR TITLE
Fixed Windows bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,19 +50,24 @@ module.exports = function(options) {
 		 */
 		function resolve(val, i, isPath) {
 			val = val.replace('~', '');
+			var isWin = /^win/.test(process.platform);
 			return Promise.resolve(System.normalize(val))
 					.then(function(normalized) {
 						return System.locate({name: normalized, metadata: {}});
 					})
 					.then(function(address) {
+						var resolvePath = address.replace('file:', '').replace('.js', '');
+						if(isWin) {
+							resolvePath = address.replace('file:///C:', '').replace('.js', '');
+						}
 						if (isPath) {
-							options.includePaths.push(
-									path.resolve(address.replace('file:', '').replace('.js', ''))
-							);
+							var rpath = path.resolve(resolvePath);
+							options.includePaths.push(mypath);
 						} else {
-							var originalRelativePath      = path.relative(
-									path.dirname(file.path),
-									path.resolve(address.replace('file:', '').replace('.js', ''))
+
+							var originalRelativePath = path.relative(
+								path.dirname(file.path),
+								path.resolve(resolvePath)
 							);
 							var originalRelativePathArray = originalRelativePath.split(path.sep);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-systemjs-resolver",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "license": "MIT",
   "repository": "clempat/gulp-systemjs-resolver",


### PR DESCRIPTION
It was not possible to load the paths under windows because file://c:

I changed the behaviour to detect the operating system and replace the path based on it.
